### PR TITLE
fix: read SLACK_WEBHOOK_URL at runtime instead of module scope

### DIFF
--- a/script/rewards/slackNotify.ts
+++ b/script/rewards/slackNotify.ts
@@ -1,5 +1,3 @@
-const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
-
 const LEVEL_EMOJI = {
   info: ":white_check_mark:",
   warning: ":warning:",
@@ -15,6 +13,7 @@ export async function notifySlack(
   message: string,
   level: "info" | "warning" | "error" = "info"
 ): Promise<void> {
+  const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
   if (!SLACK_WEBHOOK_URL) return;
 
   const prefix = LEVEL_EMOJI[level];


### PR DESCRIPTION
Moved SLACK_WEBHOOK_URL read into notifySlack() function body so it's evaluated after dotenv loads the environment. This fixes Slack notifications which were silently no-oping because the env var was undefined at import time.

Fixes the issue where SLACK_WEBHOOK_URL was being read at module scope (import time) before dotenv had loaded the `.env` file, causing all Slack notifications to silently fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)